### PR TITLE
mobile device media query added to fit even longest fortune on screen

### DIFF
--- a/index.css
+++ b/index.css
@@ -69,3 +69,13 @@ body {
     font-size: 1.2rem;
   }
 }
+
+@media only screen and (max-device-width: 600px) {
+  #fortune {
+    margin: 1rem;
+    padding: 2px;
+    line-height: 110%;
+    text-align: center;
+    font-size: 1.2rem;
+  }
+}


### PR DESCRIPTION
As the commit comment says, I just added a max-device-width media queries and tweaked settings so that even the longest fortune fits on a screen. 